### PR TITLE
允许插件通过Attribute定义库查找目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains Rider files
+.idea/

--- a/ExamplePlugin/PluginMain.cs
+++ b/ExamplePlugin/PluginMain.cs
@@ -22,6 +22,7 @@ namespace LiteLDev;
 /// Plugin Entry Class
 /// </summary>
 [PluginMain("ExamplePlugin")]
+[LibPath("plugins\\ExamplePlugin\\libs")]
 public class ExamplePlugin : IPluginInitializer
 {
     public ExamplePlugin()

--- a/ExamplePlugin/PluginMain.cs
+++ b/ExamplePlugin/PluginMain.cs
@@ -27,9 +27,13 @@ public class ExamplePlugin : IPluginInitializer
 {
     public ExamplePlugin()
     {
-        MetaData = new Dictionary<string, string>();
-        MetaData.Add("Something", "...");
+        MetaData = new Dictionary<string, string>
+        {
+            {"Something", "..."},
+            {"foo", "bar"}
+        };
     }
+
     public Version Version => new Version(2, 2, 5);
     public Dictionary<string, string> MetaData { get; }
     public string Introduction => "Example plugin for Liteloader.Net";

--- a/LiteLoader.NET/LiteLoader.NET.vcxproj
+++ b/LiteLoader.NET/LiteLoader.NET.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -283,6 +283,7 @@ copy /Y $(TargetPath) $(LocalDebuggerWorkingDirectory)\plugins\
     <ClInclude Include="Main\ClassTemplate.h" />
     <ClInclude Include="Main\Config.h" />
     <ClInclude Include="Main\Global.hpp" />
+    <ClInclude Include="Main\IPluginInitializer.hpp" />
     <ClInclude Include="Main\Loader.hpp" />
     <ClInclude Include="Main\PluginManager.h" />
     <ClInclude Include="Resource\resource.h" />

--- a/LiteLoader.NET/LiteLoader.NET.vcxproj.filters
+++ b/LiteLoader.NET/LiteLoader.NET.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Main">
@@ -676,6 +676,9 @@
     </ClInclude>
     <ClInclude Include="Header\DynamicCommand\RegisterCommand.hpp">
       <Filter>Header\DynamicCommand</Filter>
+    </ClInclude>
+    <ClInclude Include="Main\IPluginInitializer.hpp">
+      <Filter>Main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/LiteLoader.NET/Main/.NETGlobal.hpp
+++ b/LiteLoader.NET/Main/.NETGlobal.hpp
@@ -88,6 +88,7 @@ inline uint64_t do_Hash(String^ str)
 
 ref class Global {
 internal:
+    static System::Reflection::Assembly^ CurrentAssembly = nullptr;
     static Dictionary<Assembly^, IntPtr>^ ManagedPluginHandler = gcnew Dictionary<Assembly^, IntPtr>;
     static inline HMODULE __GetCurrentModule(Assembly^ asm_)
     {

--- a/LiteLoader.NET/Main/Loader.cpp
+++ b/LiteLoader.NET/Main/Loader.cpp
@@ -123,6 +123,10 @@ void LoadPlugins(std::vector<std::filesystem::path> const& assemblyPaths, Logger
 			logger.info("Plugin <{}> loaded", iter->filename().string());
 			++count;
 		}
+		catch (System::BadImageFormatException^ ex)
+		{
+			continue;
+		}
 		catch (System::Reflection::TargetInvocationException^ ex)
 		{
 			logger.error("Uncaught {} Detected!", marshalString(ex->InnerException->GetType()->ToString()));
@@ -183,7 +187,7 @@ void LoadMain()
 		}
 	}
 
-	CheekPluginEntry(assemblies, logger);
+	// CheekPluginEntry(assemblies, logger);
 
 	LoadPlugins(assemblies, logger);
 }
@@ -199,7 +203,7 @@ void CheekPluginEntry(std::vector<std::filesystem::path>& assemblyPaths, Logger&
 
 		if (info.isDotNETAssembly())
 		{
-			/*auto dllFile = fopen(iter->string().c_str(), "r");
+			auto dllFile = fopen(iter->string().c_str(), "r");
 			if (dllFile != nullptr)
 			{
 
@@ -245,8 +249,7 @@ void CheekPluginEntry(std::vector<std::filesystem::path>& assemblyPaths, Logger&
 					iter = assemblyPaths.erase(iter);
 				}
 				fclose(dllFile);
-			}*/
-			++iter;
+			}
 		}
 		else
 		{

--- a/LiteLoader.NET/Main/Loader.cpp
+++ b/LiteLoader.NET/Main/Loader.cpp
@@ -18,8 +18,30 @@ System::Reflection::Assembly^ OnAssemblyResolve(System::Object^ sender, System::
 	if (assemblyName.Name == LLNET_LOADER_NAME)
 		return System::Reflection::Assembly::GetExecutingAssembly();
 
-	return System::Reflection::Assembly::LoadFrom(System::IO::Path::Combine(LITELOADER_LIBRARY_DIR, assemblyName.Name + ".dll"));
+	auto llLibPath = System::IO::Path::Combine(LITELOADER_LIBRARY_DIR, assemblyName.Name + ".dll");
+	if (System::IO::File::Exists(llLibPath))
+	{
+		return System::Reflection::Assembly::LoadFrom(llLibPath);
+	}
+	
+	for each (auto var in LLNET::PluginManager::CustomLibPath)
+	{
+		auto libPath = System::IO::Path::Combine(var, assemblyName.Name + ".dll");
+		auto libPathWithPlugin = System::IO::Path::Combine("plugins", var, assemblyName.Name + ".dll");
+		if (System::IO::File::Exists(libPath))
+		{
+			return System::Reflection::Assembly::LoadFrom(libPath);
+		}
+		else if (System::IO::File::Exists(libPathWithPlugin))
+		{
+			return System::Reflection::Assembly::LoadFrom(libPathWithPlugin);
+		}
+	}
+
+	return nullptr;
 }
+
+void addCustomLibPath(System::Attribute^ attribute);
 
 void LoadPlugins(std::vector<std::filesystem::path> const& assemblyPaths, Logger& logger)
 {
@@ -46,13 +68,16 @@ void LoadPlugins(std::vector<std::filesystem::path> const& assemblyPaths, Logger
 					continue;
 				}
 				auto attribute = System::Attribute::GetCustomAttribute(type, LLNET::Core::PluginMainAttribute::typeid);
+				auto customLibPathAttribute = System::Attribute::GetCustomAttribute(type, LLNET::Core::LibPathAttribute::typeid);
 				if (attribute != nullptr) 
 				{
 					pluginName = ((LLNET::Core::PluginMainAttribute^) attribute)->Name;
 					auto ctor = type->GetConstructor(System::Type::EmptyTypes);
 					if (ctor != nullptr)
 					{
-						//pluginName = attribute
+						addCustomLibPath(customLibPathAttribute);
+						
+						pluginName = ((LLNET::Core::PluginMainAttribute^) attribute)->Name;
 						initializer = (LLNET::Core::IPluginInitializer^) ctor->Invoke(nullptr);
 						break;
 					}
@@ -73,9 +98,10 @@ void LoadPlugins(std::vector<std::filesystem::path> const& assemblyPaths, Logger
 			}
 			else
 			{
-				Asm->GetType(TEXT(LLNET_ENTRY_CLASS))
-					->GetMethod(TEXT(LLNET_ENTRY_METHOD))
-					->Invoke(nullptr, nullptr);
+				auto entry = Asm->GetType(TEXT(LLNET_ENTRY_CLASS))->GetMethod(TEXT(LLNET_ENTRY_METHOD));
+				auto customLibPathAttribute = System::Attribute::GetCustomAttribute(entry, LLNET::Core::LibPathAttribute::typeid);
+				addCustomLibPath(customLibPathAttribute);
+				entry->Invoke(nullptr, nullptr);
 			}
 
 			logger.info("Plugin <{}> loaded", iter->filename().string());
@@ -102,6 +128,15 @@ void LoadPlugins(std::vector<std::filesystem::path> const& assemblyPaths, Logger
 		}
 	}
 	logger.info << count << " plugin(s) loaded" << logger.endl;
+}
+
+void addCustomLibPath(System::Attribute^ attribute)
+{
+	if (attribute)
+	{
+		auto libPath = ((LLNET::Core::LibPathAttribute^) attribute)->Path;
+		LLNET::PluginManager::CustomLibPath->Add(libPath);
+	}
 }
 
 #pragma unmanaged

--- a/LiteLoader.NET/Main/PluginAttribute.h
+++ b/LiteLoader.NET/Main/PluginAttribute.h
@@ -37,4 +37,16 @@ namespace LLNET::Core
 			Name = name;
 		}
 	};
+
+	[AttributeUsage(AttributeTargets::Class | AttributeTargets::Method)]
+	public ref class LibPathAttribute sealed
+		:public Attribute
+	{
+	public:
+		property System::String^ Path;
+		LibPathAttribute(String^ path)
+		{
+			Path = path; 
+		}
+	};
 } // namespace LLNET

--- a/LiteLoader.NET/Main/PluginManager.h
+++ b/LiteLoader.NET/Main/PluginManager.h
@@ -17,7 +17,7 @@ namespace LLNET {
 		static bool unRegisterPlugin(System::String^ name);
 	internal:
 		using PluginTuple = System::Tuple< Plugin^, Assembly^>;
-		static List<String^>^ CustomLibPath = gcnew List<String^>();
+		static Dictionary<Assembly^ , String^>^ CustomLibPath = gcnew Dictionary<Assembly^, String^>();
 		static Dictionary<String^, PluginTuple^>^ ManagedPluginData = gcnew Dictionary<String^, PluginTuple^>;
 	};
 }

--- a/LiteLoader.NET/Main/PluginManager.h
+++ b/LiteLoader.NET/Main/PluginManager.h
@@ -17,6 +17,7 @@ namespace LLNET {
 		static bool unRegisterPlugin(System::String^ name);
 	internal:
 		using PluginTuple = System::Tuple< Plugin^, Assembly^>;
+		static List<String^>^ CustomLibPath = gcnew List<String^>();
 		static Dictionary<String^, PluginTuple^>^ ManagedPluginData = gcnew Dictionary<String^, PluginTuple^>;
 	};
 }


### PR DESCRIPTION
允许插件在主类或者OnPostInit方法上附加LibPath注解来定义库查找目录，并在plugins/lib目录下无法找到目标程序集时，通过自定义目录查找程序集。以解决.Net程序库众多而又无静态链接库的问题，进而使得少量依赖可以放在plugins/lib中统一化管理的同时，又能做到让成百上千个dll的插件（比如使用了ASP.Net Core、WPF、Avalonia UI的情况下）尽可能简洁美观方便管理，这种情况下如果全部放在plugins/lib反而会让plugins/lib目录不堪重负的