### PR TITLE
Fix event type check

### DIFF
--- a/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
@@ -245,7 +245,7 @@ namespace LLNET::Event::Effective
 		if (eventId != 0)
 			goto SKIP_CHECK;
 
-		auto eventType = TEvent::typeid;
+		auto eventType = ev->GetType();
 		if (!eventIds.ContainsKey(eventType))
 			return EventCode::UNREGISTERED;
 


### PR DESCRIPTION
When calling an event based on EventBase, eventType mistakenly takes a value of type LLNET.Event.Effective.EventBase.
This commit fixes this bug.