### PR TITLE
Revert back 'IsCancelled' (IgnoreCancelled) logic 

### DIFF
--- a/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
@@ -328,46 +328,46 @@ namespace LLNET::Event::Effective
 					{
 					case IS_NORMAL:
 
+						((void(*)(TEvent))(void*)func.Item1)(ev);
+						break;
+
+					case IS_INSTANCE:
+
+						((void(*)(Object^, TEvent))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
+						break;
+
+					case IS_REF:
+
+						((void(*)(TEvent%))(void*)func.Item1)(ev);
+						break;
+
+					case IS_IGNORECANCELLED:
+						
 						if (!ev->IsCancelled)
 							((void(*)(TEvent))(void*)func.Item1)(ev);
 						break;
 
-					case IS_INSTANCE:
+					case IS_INSTANCE_AND_REF:
+
+						((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
+						break;
+
+					case IS_INSTANCE_AND_IGNORECANCELLED:
 
 						if (!ev->IsCancelled)
 							((void(*)(Object^, TEvent))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
 						break;
 
-					case IS_REF:
+					case IS_REF_AND_IGNORECANCELLED:
 
 						if (!ev->IsCancelled)
 							((void(*)(TEvent%))(void*)func.Item1)(ev);
 						break;
 
-					case IS_IGNORECANCELLED:
-
-						((void(*)(TEvent))(void*)func.Item1)(ev);
-						break;
-
-					case IS_INSTANCE_AND_REF:
+					case IS_INSTANCE_AND_REF_AND_IGNORECANCELLED:
 
 						if (!ev->IsCancelled)
 							((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
-
-					case IS_INSTANCE_AND_IGNORECANCELLED:
-
-						((void(*)(Object^, TEvent))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
-
-					case IS_REF_AND_IGNORECANCELLED:
-
-						((void(*)(TEvent%))(void*)func.Item1)(ev);
-						break;
-
-					case IS_INSTANCE_AND_REF_AND_IGNORECANCELLED:
-
-						((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
 						break;
 					}
 				}

--- a/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
@@ -400,24 +400,23 @@ namespace LLNET::Event::Effective
 					{
 					case IS_REF:
 
-						if (!ev->IsCancelled)
-							((void(*)(TEvent%))(void*)func.Item1)(ev);
+						((void(*)(TEvent%))(void*)func.Item1)(ev);
 						break;
 
 					case IS_INSTANCE_AND_REF:
 
-						if (!ev->IsCancelled)
-							((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
+						((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
 						break;
 
 					case IS_REF_AND_IGNORECANCELLED:
 
-						((void(*)(TEvent%))(void*)func.Item1)(ev);
+						if (!ev->IsCancelled)
+							((void(*)(TEvent%))(void*)func.Item1)(ev);
 						break;
 
 					case IS_INSTANCE_AND_REF_AND_IGNORECANCELLED:
-
-						((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
+						if (!ev->IsCancelled)
+							((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
 						break;
 					}
 				}


### PR DESCRIPTION
Normally ignoreCancelled means that cancelled events **will not** be processed. In the commit https://github.com/LiteLDev/LiteLoader.NET/commit/4cb888019a1b9686d1049f6acb41869802821336 you have changed the IgnoreCancelled logic, so conversely, cancelled events are handled.
So I think you should revert back to the way it was