### PR TITLE
Update `EventManager`

### DIFF
--- a/LLMoney.NET/EconomySystem/EconomySystem.hpp
+++ b/LLMoney.NET/EconomySystem/EconomySystem.hpp
@@ -161,9 +161,6 @@ namespace LLMoney
 					(void*)Marshal::GetFunctionPointerForDelegate(beforeEvCallback)));
 				dynamicSymbolsMap.LLMoneyListenAfterEvent(static_cast<LLMoneyCallback>(
 					(void*)Marshal::GetFunctionPointerForDelegate(evCallback)));
-
-				EventManager::RegisterEvent<EconomySystemBeforeEvent^>();
-				EventManager::RegisterEvent<EconomySystemEvent^>();
 			}
 		}
 

--- a/LiteLoader.NET/Header/Event/EffectiveEvent/EventAttribute.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/EventAttribute.hpp
@@ -12,13 +12,11 @@ namespace LLNET::Event::Effective
     public:
         property EventPriority Priority;
         property bool IgnoreCancelled;
-        property bool IsBaseEventListener;
 
         EventHandlerAttribute()
         {
             Priority = EventPriority::NORMAL;
             IgnoreCancelled = false;
-            IsBaseEventListener = false;
         }
     };
 }

--- a/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/EventManager.hpp
@@ -10,7 +10,6 @@ constexpr int HIGHEST = 4;
 constexpr int MONITOR = 5;
 
 
-
 constexpr int IS_NORMAL = 0;
 constexpr int IS_INSTANCE = 64;
 constexpr int IS_REF = 128;
@@ -21,356 +20,366 @@ constexpr int IS_REF_AND_IGNORECANCELLED = IS_REF | IS_IGNORECANCELLED;
 constexpr int IS_INSTANCE_AND_REF_AND_IGNORECANCELLED = IS_INSTANCE | IS_REF | IS_IGNORECANCELLED;
 
 
-
 namespace LLNET::Event::Effective
 {
+    ref class NativeEventIsCancelledManager sealed
+    {
+    internal:
+        static bool current = false;
 
-	ref class NativeEventIsCancelledManager sealed
-	{
-	internal:
-		static bool current = false;
+        inline static void set(bool isCancelled);
+        inline static bool get();
+    };
 
-		inline static void set(bool isCancelled);
-		inline static bool get();
-	};
+    public ref class EventManager abstract sealed
+    {
+    internal:
+        using __IgnoreCancelled = bool;
+        using __IsRef = bool;
+        using __IsInstance = bool;
+        using __CallBackFunctionPointer = IntPtr;
+        using __ListenerType = System::Type;
+        using __HMODULE = IntPtr;
+        using __CallbackFunctionInfo = System::ValueTuple<
+            __CallBackFunctionPointer, __IgnoreCancelled, __IsRef, __IsInstance, __ListenerType^, __HMODULE>;
+        using __PermissionWithCallbackFunctions = array<List<__CallbackFunctionInfo>^>;
+        using __EventId = size_t;
+        using __EventManagerData = Dictionary<__EventId, __PermissionWithCallbackFunctions^>;
 
-	public ref class EventManager abstract sealed
-	{
-	internal:
+        using __EventIds = Dictionary<System::Type^, __EventId>;
 
-		using __IgnoreCancelled = bool;
-		using __IsRef = bool;
-		using __IsInstance = bool;
-		using __CallBackFunctionPointer = IntPtr;
-		using __ListenerType = System::Type;
-		using __HMODULE = IntPtr;
-		using __CallbackFunctionInfo = System::ValueTuple<__CallBackFunctionPointer, __IgnoreCancelled, __IsRef, __IsInstance, __ListenerType^, __HMODULE>;
-		using __PermissionWithCallbackFunctions = array<List<__CallbackFunctionInfo>^>;
-		using __EventId = size_t;
-		using __EventManagerData = Dictionary<__EventId, __PermissionWithCallbackFunctions^>;
+        static __EventManagerData eventManagerData;
+        static __EventIds eventIds;
+        static System::Random rand;
+        static List<__EventId> initializedNativeEvents;
+        static Logger::Logger^ logger;
 
-		using __EventIds = Dictionary<System::Type^, __EventId>;
+    public:
+        //public API
+        generic <typename TListener> where TListener : IEventListener
+        static void RegisterListener(__HMODULE handle);
 
-		static __EventManagerData eventManagerData;
-		static __EventIds eventIds;
-		static System::Random rand;
-		static List<__EventId> initializedNativeEvents;
-		static Logger::Logger^ logger;
+        generic <typename TListener> where TListener : IEventListener
+        static void RegisterListener();
 
-	public:
-		//public API
-		generic<typename TListener> where TListener : IEventListener
-			static void RegisterListener(__HMODULE handle);
+        static void CallEvent(IEvent^ ev);
 
-		generic<typename TListener> where TListener : IEventListener
-			static void RegisterListener();
-		
-		static void CallEvent(IEvent^ ev);
+    private:
+        static void _registerEvent(System::Type^ eventType);
 
-	private:
-		static void _registerEvent(System::Type^ eventType);
+        generic <typename TEvent> where TEvent : IEvent
+        static void _callEvent(TEvent ev, List<__CallbackFunctionInfo>^* pfuncs);
 
-		generic<typename TEvent> where TEvent : IEvent
-			static void _callEvent(TEvent ev, List<__CallbackFunctionInfo>^* pfuncs);
+        static bool _isNativeEventId(__EventId eventId);
 
-		static bool _isNativeEventId(__EventId eventId);
+    internal:
+        generic <typename TEvent> where TEvent : IEvent, INativeEvent
+        static void _callNativeEvent(TEvent% ev, __EventId eventId);
 
-	internal:
-		generic<typename TEvent> where TEvent : IEvent, INativeEvent
-		static void _callNativeEvent(TEvent% ev, __EventId eventId);
+        generic <typename TEvent> where TEvent : IEvent, INativeEvent
+        static void _registerNativeEvent(__EventId id);
 
-		generic<typename TEvent> where TEvent : IEvent, INativeEvent
-			static void _registerNativeEvent(__EventId id);
-
-		static void _setLogger(::Logger& logger);
-	};
+        static void _setLogger(::Logger& logger);
+    };
 }
-
-
 
 
 //#include "LLNETEvents.hpp"
 
 namespace LLNET::Event::Effective
 {
-	inline bool EventManager::_isNativeEventId(__EventId eventId)
-	{
-	    return 0 < eventId && eventId <= 128;
-	}
+    inline bool EventManager::_isNativeEventId(__EventId eventId)
+    {
+        return 0 < eventId && eventId <= 128;
+    }
 
-	inline void EventManager::_registerEvent(System::Type^ eventType)
-	{
-		__EventId eventId = 0;
-		
-		do
-		{
-			eventId = __EventId(rand.Next()) ^ __EventId(rand.Next() & 7);
-		} while (eventIds.ContainsValue(eventId) || _isNativeEventId(eventId));
+    inline void EventManager::_registerEvent(System::Type^ eventType)
+    {
+        __EventId eventId = 0;
 
-		eventIds.TryAdd(eventType, eventId);
-		eventManagerData.TryAdd(eventIds[eventType], gcnew __PermissionWithCallbackFunctions(6) { nullptr });
-	}
+        do
+        {
+            eventId = static_cast<__EventId>(rand.Next()) ^ static_cast<__EventId>(rand.Next() & 7);
+        }
+        while (eventIds.ContainsValue(eventId) || _isNativeEventId(eventId));
 
-
-
-	generic<typename TEvent> where TEvent : IEvent, INativeEvent
-		inline void EventManager::_registerNativeEvent(__EventId id)
-	{
-		eventIds.Add(TEvent::typeid, id);
-		eventManagerData.Add(id, gcnew __PermissionWithCallbackFunctions(6) { nullptr });
-	}
+        eventIds.TryAdd(eventType, eventId);
+        eventManagerData.TryAdd(eventIds[eventType], gcnew __PermissionWithCallbackFunctions(6){nullptr});
+    }
 
 
-
-	generic<typename TListener> where TListener : IEventListener
-		inline void EventManager::RegisterListener()
-	{
-		RegisterListener<TListener>(IntPtr(GlobalClass::__GetCurrentModule(Assembly::GetCallingAssembly())));
-	}
-
-
-
-	generic<typename TListener> where TListener : IEventListener
-		inline void EventManager::RegisterListener(__HMODULE handle)
-	{
-
-		using __IgnoreCancelled = bool;
-		using __IsStatic = bool;
-		using __IsByRef = bool;
+    generic <typename TEvent> where TEvent : IEvent, INativeEvent
+    void EventManager::_registerNativeEvent(__EventId id)
+    {
+        eventIds.Add(TEvent::typeid, id);
+        eventManagerData.Add(id, gcnew __PermissionWithCallbackFunctions(6){nullptr});
+    }
 
 
-		auto listenerType = TListener::typeid;
-		auto Methods = listenerType->GetMethods(
-			BindingFlags::Public |
-			BindingFlags::NonPublic |
-			BindingFlags::Static |
-			BindingFlags::Instance);
-
-		auto listenerMethodDatas = gcnew List<System::ValueTuple<MethodInfo^, EventPriority, __IgnoreCancelled, __IsStatic, __IsByRef>>;
-
-		for each (auto method in Methods)
-		{
-			auto evHandlerAttrArr = method->GetCustomAttributes(EventHandlerAttribute::typeid, false);
-			if (evHandlerAttrArr->Length == 0)
-				continue;
-			else
-			{
-				if (!method->IsStatic)
-				{
-					auto defaultCtor = listenerType->GetConstructor(System::Array::Empty<System::Type^>());
-					if (defaultCtor == nullptr)
-						throw gcnew RegisterEventListenerException("Handler must be static or it's class must have default constructor!  at Handler:<" + listenerType->Name + "." + method->Name + ">");
-				}
-
-				auto evHandlerAttr = static_cast<EventHandlerAttribute^>(evHandlerAttrArr[0]);
-				listenerMethodDatas->Add(System::ValueTuple<MethodInfo^, EventPriority, __IgnoreCancelled, __IsStatic, __IsByRef>
-				{
-					method,
-					evHandlerAttr->Priority,
-					evHandlerAttr->IgnoreCancelled,
-					!method->IsStatic,
-					false
-				});
-			}
-		}
-
-		for each (auto methodData in listenerMethodDatas)
-		{
-			auto method = methodData.Item1;
-
-			auto methodRetType = method->ReturnType;
-
-			if (methodRetType != void::typeid)
-				throw gcnew RegisterEventListenerException("Handler.ReturnType must be System.Void!  at Handler:<" + listenerType->Name + "." + method->Name + ">");
+    generic <typename TListener> where TListener : IEventListener
+    void EventManager::RegisterListener()
+    {
+        RegisterListener<TListener>(IntPtr(GlobalClass::__GetCurrentModule(Assembly::GetCallingAssembly())));
+    }
 
 
-			auto methodParam = method->GetParameters();
-
-			if (methodParam->Length != 1)
-				goto PARAM_CHECK_STEP1_FAILED;
-
-			__IsRef isref = false;
-			auto paramType = methodParam[0]->ParameterType;
-			auto elementParamType = paramType;
-
-			if (paramType->IsByRef)
-			{
-				isref = true;
-				elementParamType = paramType->GetElementType();
-			}
-
-			auto paramInterfaces = elementParamType->GetInterfaces();
-			for each (auto Interface in paramInterfaces)
-			{
-				if (Interface == IEvent::typeid)
-					goto PARAM_CHECK_STEP1_SUCCEED;
-			}
+    generic <typename TListener> where TListener : IEventListener
+    void EventManager::RegisterListener(__HMODULE handle)
+    {
+        using __IgnoreCancelled = bool;
+        using __IsStatic = bool;
+        using __IsByRef = bool;
 
 
-		PARAM_CHECK_STEP1_FAILED:
-			throw gcnew RegisterEventListenerException("Handler can only have one parameter which the type is based on IEvent!  at Handler:<" + listenerType->Name + "." + method->Name + ">");
+        auto listenerType = TListener::typeid;
+        auto Methods = listenerType->GetMethods(
+            BindingFlags::Public |
+            BindingFlags::NonPublic |
+            BindingFlags::Static |
+            BindingFlags::Instance);
 
-		PARAM_CHECK_STEP1_SUCCEED:
+        auto listenerMethodDatas = gcnew List<System::ValueTuple<
+            MethodInfo^, EventPriority, __IgnoreCancelled, __IsStatic, __IsByRef>>;
 
-			if (!eventIds.ContainsKey(elementParamType))
-				_registerEvent(elementParamType);
+        for each (auto method in Methods)
+        {
+            auto evHandlerAttrArr = method->GetCustomAttributes(EventHandlerAttribute::typeid, false);
+            if (evHandlerAttrArr->Length == 0)
+                continue;
+            else
+            {
+                if (!method->IsStatic)
+                {
+                    auto defaultCtor = listenerType->GetConstructor(System::Array::Empty<System::Type^>());
+                    if (defaultCtor == nullptr)
+                        throw gcnew RegisterEventListenerException(
+                            "Handler must be static or it's class must have default constructor!  at Handler:<" +
+                            listenerType->Name + "." + method->Name + ">");
+                }
 
-			auto eventId = eventIds[elementParamType];
-			bool isNativeEventHandler = _isNativeEventId(eventId);
+                auto evHandlerAttr = static_cast<EventHandlerAttribute^>(evHandlerAttrArr[0]);
+                listenerMethodDatas->Add(
+                    System::ValueTuple<MethodInfo^, EventPriority, __IgnoreCancelled, __IsStatic, __IsByRef>
+                    {
+                        method,
+                        evHandlerAttr->Priority,
+                        evHandlerAttr->IgnoreCancelled,
+                        !method->IsStatic,
+                        false
+                    });
+            }
+        }
 
-			if (isref)
-			{
-				methodData.Item5 = true;
-			}
-			else
-			{
-				if (isNativeEventHandler)
-				{
-					throw gcnew RegisterEventListenerException("Parameter of the native event handler must be passed by reference (use 'in' or 'ref' keyword in C#)!  at Handler:<" + listenerType->Name + "." + method->Name + ">");
-				}
-			}
+        for each (auto methodData in listenerMethodDatas)
+        {
+            auto method = methodData.Item1;
 
-			auto eventPriority = (int)methodData.Item2;
+            auto methodRetType = method->ReturnType;
 
-			auto callbackFuncArr = eventManagerData[eventId];
+            if (methodRetType != void::typeid)
+                throw gcnew RegisterEventListenerException(
+                    "Handler.ReturnType must be System.Void!  at Handler:<" + listenerType->Name + "." + method->Name +
+                    ">");
 
-			if (callbackFuncArr[eventPriority] == nullptr)
-				callbackFuncArr[eventPriority] = gcnew List<__CallbackFunctionInfo>;
 
-			callbackFuncArr[eventPriority]->Add(
-				__CallbackFunctionInfo(
-					method->MethodHandle.GetFunctionPointer(),
-					methodData.Item3,
-					isref,
-					methodData.Item4,
-					methodData.Item4 ? listenerType : nullptr,
-					handle));
+            auto methodParam = method->GetParameters();
 
-			if (isNativeEventHandler)
-			{
-				if (!initializedNativeEvents.Contains(eventId))
-					elementParamType
-					->GetMethod("_init", BindingFlags::Static | BindingFlags::NonPublic)
-					->Invoke(nullptr, System::Array::Empty<System::Type^>());
-				initializedNativeEvents.Add(eventId);
-			}
-		}
-	}
+            if (methodParam->Length != 1)
+                goto PARAM_CHECK_STEP1_FAILED;
 
-	inline void EventManager::CallEvent(IEvent^ ev)
-	{
-		for (auto eventType = ev->GetType(); eventType != EventBase::typeid && eventType != Object::typeid; eventType = eventType->BaseType)
-		{
-			if (!eventIds.ContainsKey(eventType))
-				continue;
+            __IsRef isref = false;
+            auto paramType = methodParam[0]->ParameterType;
+            auto elementParamType = paramType;
 
-			auto funcs = eventManagerData[eventIds[eventType]];
+            if (paramType->IsByRef)
+            {
+                isref = true;
+                elementParamType = paramType->GetElementType();
+            }
+
+            auto paramInterfaces = elementParamType->GetInterfaces();
+            for each (auto Interface in paramInterfaces)
+            {
+                if (Interface == IEvent::typeid)
+                    goto PARAM_CHECK_STEP1_SUCCEED;
+            }
+
+
+        PARAM_CHECK_STEP1_FAILED:
+            throw gcnew RegisterEventListenerException(
+                "Handler can only have one parameter which the type is based on IEvent!  at Handler:<" + listenerType->
+                Name + "." + method->Name + ">");
+
+        PARAM_CHECK_STEP1_SUCCEED:
+
+            if (!eventIds.ContainsKey(elementParamType))
+                _registerEvent(elementParamType);
+
+            auto eventId = eventIds[elementParamType];
+            bool isNativeEventHandler = _isNativeEventId(eventId);
+
+            if (isref)
+            {
+                methodData.Item5 = true;
+            }
+            else
+            {
+                if (isNativeEventHandler)
+                {
+                    throw gcnew RegisterEventListenerException(
+                        "Parameter of the native event handler must be passed by reference (use 'in' or 'ref' keyword in C#)!  at Handler:<"
+                        + listenerType->Name + "." + method->Name + ">");
+                }
+            }
+
+            auto eventPriority = static_cast<int>(methodData.Item2);
+
+            auto callbackFuncArr = eventManagerData[eventId];
+
+            if (callbackFuncArr[eventPriority] == nullptr)
+                callbackFuncArr[eventPriority] = gcnew List<__CallbackFunctionInfo>;
+
+            callbackFuncArr[eventPriority]->Add(
+                __CallbackFunctionInfo(
+                    method->MethodHandle.GetFunctionPointer(),
+                    methodData.Item3,
+                    isref,
+                    methodData.Item4,
+                    methodData.Item4 ? listenerType : nullptr,
+                    handle));
+
+            if (isNativeEventHandler)
+            {
+                if (!initializedNativeEvents.Contains(eventId))
+                    elementParamType
+                        ->GetMethod("_init", BindingFlags::Static | BindingFlags::NonPublic)
+                        ->Invoke(nullptr, System::Array::Empty<System::Type^>());
+                initializedNativeEvents.Add(eventId);
+            }
+        }
+    }
+
+    inline void EventManager::CallEvent(IEvent^ ev)
+    {
+        for (auto eventType = ev->GetType(); eventType != EventBase::typeid && eventType != Object::typeid; eventType =
+             eventType->BaseType)
+        {
+            if (!eventIds.ContainsKey(eventType))
+                continue;
+
+            auto funcs = eventManagerData[eventIds[eventType]];
             const pin_ptr<List<__CallbackFunctionInfo>^> pFuncs = &funcs[0];
 
-			_callEvent(ev, pFuncs);
-		}
-	}
+            _callEvent(ev, pFuncs);
+        }
+    }
 
-	generic<typename TEvent> where TEvent : IEvent
-		inline void EventManager::_callEvent(TEvent ev, List<__CallbackFunctionInfo>^* pfuncs)
-	{
-		for (int i = 0; i < 6; i++)
-		{
-			auto funcs = pfuncs[i];
-			if (funcs == nullptr)
-				continue;
+    generic <typename TEvent> where TEvent : IEvent
+    void EventManager::_callEvent(TEvent ev, List<__CallbackFunctionInfo>^* pfuncs)
+    {
+        for (int i = 0; i < 6; i++)
+        {
+            auto funcs = pfuncs[i];
+            if (funcs == nullptr)
+                continue;
 
-			for each (auto func in funcs)
-			{
-				String^ handlerName = func.Item1.ToString();
+            for each (auto func in funcs)
+            {
+                String^ handlerName = func.Item1.ToString();
 
-				int callingmode = (func.Item2 ? IS_IGNORECANCELLED : 0) | (func.Item3 ? IS_REF : 0) | (func.Item4 ? IS_INSTANCE : 0);
+                int callingmode = (func.Item2 ? IS_IGNORECANCELLED : 0) | (func.Item3 ? IS_REF : 0) | (
+                    func.Item4 ? IS_INSTANCE : 0);
 
-				try
-				{
-					switch (callingmode)
-					{
-					case IS_NORMAL:
+                try
+                {
+                    switch (callingmode)
+                    {
+                    case IS_NORMAL:
 
-						((void(*)(TEvent))(void*)func.Item1)(ev);
-						break;
+                        static_cast<void(*)(TEvent)>(static_cast<void*>(func.Item1))(ev);
+                        break;
 
-					case IS_INSTANCE:
+                    case IS_INSTANCE:
 
-						((void(*)(Object^, TEvent))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
+                        static_cast<void(*)(Object^, TEvent)>(static_cast<void*>(func.Item1))(
+                            System::Activator::CreateInstance(func.Item5), ev);
+                        break;
 
-					case IS_REF:
+                    case IS_REF:
 
-						((void(*)(TEvent%))(void*)func.Item1)(ev);
-						break;
+                        static_cast<void(*)(TEvent%)>(static_cast<void*>(func.Item1))(ev);
+                        break;
 
-					case IS_IGNORECANCELLED:
+                    case IS_IGNORECANCELLED:
 
-						if (!ev->IsCancelled)
-							((void(*)(TEvent))(void*)func.Item1)(ev);
-						break;
+                        if (!ev->IsCancelled)
+                            static_cast<void(*)(TEvent)>(static_cast<void*>(func.Item1))(ev);
+                        break;
 
-					case IS_INSTANCE_AND_REF:
+                    case IS_INSTANCE_AND_REF:
 
-						((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
+                        static_cast<void(*)(Object^, TEvent%)>(static_cast<void*>(func.Item1))(
+                            System::Activator::CreateInstance(func.Item5), ev);
+                        break;
 
-					case IS_INSTANCE_AND_IGNORECANCELLED:
+                    case IS_INSTANCE_AND_IGNORECANCELLED:
 
-						if (!ev->IsCancelled)
-							((void(*)(Object^, TEvent))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
+                        if (!ev->IsCancelled)
+                            static_cast<void(*)(Object^, TEvent)>(static_cast<void*>(func.Item1))(
+                                System::Activator::CreateInstance(func.Item5), ev);
+                        break;
 
-					case IS_REF_AND_IGNORECANCELLED:
+                    case IS_REF_AND_IGNORECANCELLED:
 
-						if (!ev->IsCancelled)
-							((void(*)(TEvent%))(void*)func.Item1)(ev);
-						break;
+                        if (!ev->IsCancelled)
+                            static_cast<void(*)(TEvent%)>(static_cast<void*>(func.Item1))(ev);
+                        break;
 
-					case IS_INSTANCE_AND_REF_AND_IGNORECANCELLED:
+                    case IS_INSTANCE_AND_REF_AND_IGNORECANCELLED:
 
-						if (!ev->IsCancelled)
-							((void(*)(Object^, TEvent%))(void*)func.Item1)(System::Activator::CreateInstance(func.Item5), ev);
-						break;
-					}
-				}
-				catch (Exception^ ex)
-				{
-					if (logger != nullptr)
-					    logger->error->WriteLine("Exception thrown when handling an event:" + System::Environment::NewLine + ex);
-				}
-			}
-		}
-	}
+                        if (!ev->IsCancelled)
+                            static_cast<void(*)(Object^, TEvent%)>(static_cast<void*>(func.Item1))(
+                                System::Activator::CreateInstance(func.Item5), ev);
+                        break;
+                    }
+                }
+                catch (Exception^ ex)
+                {
+                    if (logger != nullptr)
+                        logger->error->WriteLine(
+                            "Exception thrown when handling an event:" + System::Environment::NewLine + ex);
+                }
+            }
+        }
+    }
 
-	generic<typename TEvent> where TEvent : IEvent, INativeEvent
-	    inline void EventManager::_callNativeEvent(TEvent% ev, __EventId eventId)
-	{
-		auto functions = eventManagerData[eventId];
-		pin_ptr<List<__CallbackFunctionInfo>^> pfunctions = &functions[0];
+    generic <typename TEvent> where TEvent : IEvent, INativeEvent
+    void EventManager::_callNativeEvent(TEvent% ev, __EventId eventId)
+    {
+        auto functions = eventManagerData[eventId];
+        pin_ptr<List<__CallbackFunctionInfo>^> pfunctions = &functions[0];
 
-		return _callEvent(ev, pfunctions);
-	}
+        return _callEvent(ev, pfunctions);
+    }
 
 
-	inline void NativeEventIsCancelledManager::set(bool isCancelled)
-	{
-		current = isCancelled;
-	}
+    inline void NativeEventIsCancelledManager::set(bool isCancelled)
+    {
+        current = isCancelled;
+    }
 
-	inline bool NativeEventIsCancelledManager::get()
-	{
-		return current;
-	}
+    inline bool NativeEventIsCancelledManager::get()
+    {
+        return current;
+    }
 
-	inline void EventBase::Call()
-	{
-		EventManager::CallEvent(this);
-	}
+    inline void EventBase::Call()
+    {
+        EventManager::CallEvent(this);
+    }
 
     inline void EventManager::_setLogger(::Logger& value)
-	{
-	    logger = gcnew Logger::Logger(marshalString(value.title));
-	}
+    {
+        logger = gcnew Logger::Logger(marshalString(value.title));
+    }
 }

--- a/LiteLoader.NET/Header/Event/EffectiveEvent/LLNETEvents.hpp
+++ b/LiteLoader.NET/Header/Event/EffectiveEvent/LLNETEvents.hpp
@@ -141,7 +141,7 @@ internal:																												\
 	{																													\
 		NativeEventIsCancelledManager::set(false);																		\
 		auto% _ev = *(eventName*)&ev;																					\
-		EventManager::_callNativeEventInternal(_ev, EventId);															\
+		EventManager::_callNativeEvent(_ev, EventId);															\
 		return !_ev.IsCancelled;																						\
 	}																													\
 	static void _init()																									\
@@ -271,7 +271,7 @@ namespace LLNET::Event::Effective::NativeEvents
         static bool _nativeCallback(::Event::PlayerJumpEvent & ev)
         {
             auto% _ev = *(PlayerJumpEvent*)&ev;
-            EventManager::_callNativeEventInternal(_ev, EventId);
+            EventManager::_callNativeEvent(_ev, EventId);
             return !_ev.IsCancelled;
         }
         static PlayerJumpEvent()

--- a/LiteLoader.NET/Kernel/Event/LLNETEvents.cpp
+++ b/LiteLoader.NET/Kernel/Event/LLNETEvents.cpp
@@ -1,89 +1,86 @@
 #include "../../Header/Event/EffectiveEvent/EventManager.hpp"
 #include "../../Header/Event/EffectiveEvent/LLNETEvents.hpp"
 
-void InitEvents()
+void InitEvents(::Logger& logger)
 {
-    LLNET::Event::Effective::EventManager::_initEvents();
-}
+    using namespace LLNET::Event::Effective;
 
-inline void LLNET::Event::Effective::EventManager::_initEvents()
-{
-    using namespace NativeEvents;
+    EventManager::_setLogger(logger);
 
-#define REGISTER_NATIVE_EVENT(_event) _registerEventInternal<_event>(_event::EventId)
+#define REGISTER_NATIVE_EVENT(_event) EventManager::_registerNativeEvent<_event>(_event::EventId)
 
-    REGISTER_NATIVE_EVENT(PlayerPreJoinEvent);
-    REGISTER_NATIVE_EVENT(PlayerJoinEvent);
-    REGISTER_NATIVE_EVENT(PlayerLeftEvent);
-    REGISTER_NATIVE_EVENT(PlayerRespawnEvent);
-    REGISTER_NATIVE_EVENT(PlayerChatEvent);
-    REGISTER_NATIVE_EVENT(PlayerUseItemEvent);
-    REGISTER_NATIVE_EVENT(PlayerUseItemOnEvent);
-    REGISTER_NATIVE_EVENT(PlayerChangeDimEvent);
-    REGISTER_NATIVE_EVENT(PlayerJumpEvent);
-    REGISTER_NATIVE_EVENT(PlayerSneakEvent);
-    REGISTER_NATIVE_EVENT(PlayerAttackEvent);
-    REGISTER_NATIVE_EVENT(PlayerAttackBlockEvent);
-    REGISTER_NATIVE_EVENT(PlayerDieEvent);
-    REGISTER_NATIVE_EVENT(PlayerPickupItemEvent);
-    REGISTER_NATIVE_EVENT(PlayerDropItemEvent);
-    REGISTER_NATIVE_EVENT(PlayerEatEvent);
-    REGISTER_NATIVE_EVENT(PlayerConsumeTotemEvent);
-    REGISTER_NATIVE_EVENT(PlayerCmdEvent);
-    REGISTER_NATIVE_EVENT(PlayerDestroyBlockEvent);
-    REGISTER_NATIVE_EVENT(PlayerPlaceBlockEvent);
-    REGISTER_NATIVE_EVENT(PlayerEffectChangedEvent);
-    REGISTER_NATIVE_EVENT(PlayerStartDestroyBlockEvent);
-    REGISTER_NATIVE_EVENT(PlayerOpenContainerEvent);
-    REGISTER_NATIVE_EVENT(PlayerCloseContainerEvent);
-    REGISTER_NATIVE_EVENT(PlayerInventoryChangeEvent);
-    REGISTER_NATIVE_EVENT(PlayerMoveEvent);
-    REGISTER_NATIVE_EVENT(PlayerSprintEvent);
-    REGISTER_NATIVE_EVENT(PlayerSetArmorEvent);
-    REGISTER_NATIVE_EVENT(PlayerUseRespawnAnchorEvent);
-    REGISTER_NATIVE_EVENT(PlayerOpenContainerScreenEvent);
-    REGISTER_NATIVE_EVENT(PlayerUseFrameBlockEvent);
-    REGISTER_NATIVE_EVENT(PlayerExperienceAddEvent);
-    REGISTER_NATIVE_EVENT(MobHurtEvent);
-    REGISTER_NATIVE_EVENT(MobDieEvent);
-    REGISTER_NATIVE_EVENT(EntityExplodeEvent);
-    REGISTER_NATIVE_EVENT(ProjectileHitEntityEvent);
-    REGISTER_NATIVE_EVENT(WitherBossDestroyEvent);
-    REGISTER_NATIVE_EVENT(EntityRideEvent);
-    REGISTER_NATIVE_EVENT(EntityStepOnPressurePlateEvent);
-    REGISTER_NATIVE_EVENT(NpcCmdEvent);
-    REGISTER_NATIVE_EVENT(ProjectileSpawnEvent);
-    REGISTER_NATIVE_EVENT(ProjectileCreatedEvent);
-    REGISTER_NATIVE_EVENT(ItemUseOnActorEvent);
-    REGISTER_NATIVE_EVENT(BlockInteractedEvent);
-    REGISTER_NATIVE_EVENT(ArmorStandChangeEvent);
-    REGISTER_NATIVE_EVENT(BlockExplodeEvent);
-    REGISTER_NATIVE_EVENT(EntityTransformEvent);
-    REGISTER_NATIVE_EVENT(ContainerChangeEvent);
-    REGISTER_NATIVE_EVENT(PistonPushEvent);
-    REGISTER_NATIVE_EVENT(PistonTryPushEvent);
-    REGISTER_NATIVE_EVENT(RedStoneUpdateEvent);
-    REGISTER_NATIVE_EVENT(BlockExplodedEvent);
-    REGISTER_NATIVE_EVENT(LiquidSpreadEvent);
-    REGISTER_NATIVE_EVENT(ProjectileHitBlockEvent);
-    REGISTER_NATIVE_EVENT(HopperSearchItemEvent);
-    REGISTER_NATIVE_EVENT(HopperPushOutEvent);
-    REGISTER_NATIVE_EVENT(BlockChangedEvent);
-    REGISTER_NATIVE_EVENT(FarmLandDecayEvent);
-    REGISTER_NATIVE_EVENT(FireSpreadEvent);
-    REGISTER_NATIVE_EVENT(CmdBlockExecuteEvent);
-    REGISTER_NATIVE_EVENT(ConsoleCmdEvent);
-    REGISTER_NATIVE_EVENT(PlayerScoreChangedEvent);
-    REGISTER_NATIVE_EVENT(ConsoleOutputEvent);
-    REGISTER_NATIVE_EVENT(PostInitEvent);
-    REGISTER_NATIVE_EVENT(ServerStartedEvent);
-    REGISTER_NATIVE_EVENT(ServerStoppedEvent);
-    REGISTER_NATIVE_EVENT(RegCmdEvent);
-    REGISTER_NATIVE_EVENT(PlayerBedEnterEvent);
-    REGISTER_NATIVE_EVENT(ScriptPluginManagerEvent);
-    REGISTER_NATIVE_EVENT(MobSpawnEvent);
-    REGISTER_NATIVE_EVENT(BlockPlacedByPlayerEvent);
-    REGISTER_NATIVE_EVENT(FormResponsePacketEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerPreJoinEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerJoinEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerLeftEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerRespawnEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerChatEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerUseItemEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerUseItemOnEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerChangeDimEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerJumpEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerSneakEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerAttackEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerAttackBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerDieEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerPickupItemEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerDropItemEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerEatEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerConsumeTotemEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerCmdEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerDestroyBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerPlaceBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerEffectChangedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerStartDestroyBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerOpenContainerEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerCloseContainerEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerInventoryChangeEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerMoveEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerSprintEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerSetArmorEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerUseRespawnAnchorEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerOpenContainerScreenEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerUseFrameBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerExperienceAddEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::MobHurtEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::MobDieEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::EntityExplodeEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ProjectileHitEntityEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::WitherBossDestroyEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::EntityRideEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::EntityStepOnPressurePlateEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::NpcCmdEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ProjectileSpawnEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ProjectileCreatedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ItemUseOnActorEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::BlockInteractedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ArmorStandChangeEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::BlockExplodeEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::EntityTransformEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ContainerChangeEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PistonPushEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PistonTryPushEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::RedStoneUpdateEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::BlockExplodedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::LiquidSpreadEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ProjectileHitBlockEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::HopperSearchItemEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::HopperPushOutEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::BlockChangedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::FarmLandDecayEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::FireSpreadEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::CmdBlockExecuteEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ConsoleCmdEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerScoreChangedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ConsoleOutputEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PostInitEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ServerStartedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ServerStoppedEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::RegCmdEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::PlayerBedEnterEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::ScriptPluginManagerEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::MobSpawnEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::BlockPlacedByPlayerEvent);
+    REGISTER_NATIVE_EVENT(NativeEvents::FormResponsePacketEvent);
 }
 
 #define CallEventAPI_Imp(_event,...) void _event::CallEvent(__VA_ARGS__)

--- a/LiteLoader.NET/Main/Loader.cpp
+++ b/LiteLoader.NET/Main/Loader.cpp
@@ -48,11 +48,11 @@ void LoadMain()
 }
 
 #pragma managed
-extern void InitEvents();
+extern void InitEvents(Logger& logger);
 
 void Init(Logger& logger)
 {
-	InitEvents();
+	InitEvents(logger);
 	System::AppDomain::CurrentDomain->AssemblyResolve += gcnew System::ResolveEventHandler(&OnAssemblyResolve);
 	auto LLNET_Asm = Assembly::GetExecutingAssembly();
 	GlobalClass::ManagedModuleHandler->TryAdd(LLNET_Asm, IntPtr(::LL::getPlugin(LLNET_LOADER_NAME)->handle));


### PR DESCRIPTION
Major changes:
- Removed `EventHandlerAttribute.IsBaseEventListener`
- Changed handle base event system (#31) - old code worked only for manually registered events (using `EventManager.RegisterEvent`), so it was inconvenient
- Removed unnecessary `EventManager` public methods: `RegisterEvent`, `GetEventId`, `GetLastCallingExceptions`
- Now exceptions thrown by the event handler are logged immediately in the console, instead of being saved in `lastExceptions`
- Removed the result of the event call (`EventCode`) - because when you call an event, you don't need to know how successfully it was handled :)