### PR TITLE
Include `LiteLoader.NET.xml` file in release archive

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,7 @@ jobs:
         cp -f x64/Release/Ijwhost.dll output/RELEASE/lib/Ijwhost.dll
         cp -f x64/Release/LLMoney.NET.dll output/RELEASE/lib/dotnet/LLMoney.NET.dll
         cp -f x64/Release/LiteLoader.NET.dll output/RELEASE/LiteLoader/LiteLoader.NET.dll
+        cp -f x64/Release/LiteLoader.NET.xml output/RELEASE/LiteLoader/LiteLoader.NET.xml
         cp -f x64/Release/LiteLoader.NET.runtimeconfig.json output/RELEASE/LiteLoader/LiteLoader.NET.runtimeconfig.json
         mkdir output/PDB/
         cp -f x64/Release/*.pdb output/PDB/


### PR DESCRIPTION
In order for the XML documentation to work, the folder that contains LiteLoader.NET.dll, to which the plugin refers, must also contain LiteLoader.NET.xml